### PR TITLE
📦️ Rename the package to `hora-skills-ort-furo`

### DIFF
--- a/lib/equip/CommandLineArguments.js
+++ b/lib/equip/CommandLineArguments.js
@@ -1,5 +1,5 @@
 /**
- * The arguments given to the `hora-skills-furo` command.
+ * The arguments given to the `hora-skills-ort-furo` command.
  *
  * Both `--name value` and `--name=value` are accepted, and anything that is neither an
  * option name nor the value following one is read as a command name.

--- a/lib/equip/HoraSkillsCli.js
+++ b/lib/equip/HoraSkillsCli.js
@@ -7,7 +7,7 @@ import SkillsInstaller from './SkillsInstaller.js'
 import CLI_COMMAND from './constants/CLI_COMMAND.js'
 
 /**
- * The `hora-skills-furo` command.
+ * The `hora-skills-ort-furo` command.
  *
  * It installs every skill this package distributes into a consuming repository, and
  * removes what an earlier run of it installed. Which skills a repository equips is
@@ -177,7 +177,7 @@ export default class HoraSkillsCli {
    */
   static get usageText () {
     return [
-      'Usage: hora-skills-furo <command> [options]',
+      'Usage: hora-skills-ort-furo <command> [options]',
       '',
       'Commands:',
       '  install    Install every skill this package distributes, replacing the installed ones',

--- a/lib/equip/SkillsInstaller.js
+++ b/lib/equip/SkillsInstaller.js
@@ -88,7 +88,7 @@ export default class SkillsInstaller {
   static get manifestPathSegments () {
     return [
       '.hora',
-      'hora-skills-furo.json',
+      'hora-skills-ort-furo.json',
     ]
   }
 

--- a/lib/equip/SkillsManifestFile.js
+++ b/lib/equip/SkillsManifestFile.js
@@ -16,7 +16,7 @@ import path from 'node:path'
  *   "version": "0.1.0",
  *   "installations": {
  *     ".claude/skills": {
- *       "skillNames": ["hf-jsdoc", "hf-naming"]
+ *       "skillNames": ["hof-jsdoc", "hof-naming"]
  *     }
  *   }
  * }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@openreachtech/hora-skills-furo",
+  "name": "@openreachtech/hora-skills-ort-furo",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@openreachtech/hora-skills-furo",
+      "name": "@openreachtech/hora-skills-ort-furo",
       "version": "0.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -1908,7 +1908,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihof-1.12.2.tgz",
       "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
       "cpu": [
         "arm"
@@ -1922,7 +1922,7 @@
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihof-1.12.2.tgz",
       "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
       "cpu": [
         "arm"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openreachtech/hora-skills-furo",
+  "name": "@openreachtech/hora-skills-ort-furo",
   "version": "0.0.0",
   "description": "Distributes the furo frontend skills used to develop with Hora Kit.",
   "type": "module",
@@ -9,7 +9,7 @@
     "lib/"
   ],
   "bin": {
-    "hora-skills-furo": "lib/equip/hora-skills-furo.js"
+    "hora-skills-ort-furo": "lib/equip/hora-skills-ort-furo.js"
   },
   "keywords": [
     "hora",
@@ -27,14 +27,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openreachtech/hora-skills-furo.git"
+    "url": "git+https://github.com/openreachtech/hora-skills-ort-furo.git"
   },
   "author": "Open Reach Tech Inc.",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/openreachtech/hora-skills-furo/issues"
+    "url": "https://github.com/openreachtech/hora-skills-ort-furo/issues"
   },
-  "homepage": "https://github.com/openreachtech/hora-skills-furo#readme",
+  "homepage": "https://github.com/openreachtech/hora-skills-ort-furo#readme",
   "dependencies": {
   },
   "devDependencies": {

--- a/tests/__tests__/equip/HoraSkillsCli.js
+++ b/tests/__tests__/equip/HoraSkillsCli.js
@@ -363,7 +363,7 @@ describe('HoraSkillsCli', () => {
           override: {
             installResult: {
               installedSkillNames: [
-                'hf-query-resolver',
+                'hof-query-resolver',
               ],
               removedSkillNames: [],
             },
@@ -374,11 +374,11 @@ describe('HoraSkillsCli', () => {
           override: {
             installResult: {
               installedSkillNames: [
-                'hf-naming',
-                'hf-jsdoc',
+                'hof-naming',
+                'hof-jsdoc',
               ],
               removedSkillNames: [
-                'hf-css',
+                'hof-css',
               ],
             },
           },
@@ -1166,7 +1166,7 @@ describe('HoraSkillsCli', () => {
               'install',
             ],
           },
-          expected: '/consumer/.hora/hora-skills-furo.json',
+          expected: '/consumer/.hora/hora-skills-ort-furo.json',
         },
         {
           input: {
@@ -1176,7 +1176,7 @@ describe('HoraSkillsCli', () => {
               'tools/skills',
             ],
           },
-          expected: '/consumer/.hora/hora-skills-furo.json',
+          expected: '/consumer/.hora/hora-skills-ort-furo.json',
         },
       ]
 
@@ -1206,17 +1206,17 @@ describe('HoraSkillsCli', () => {
             ],
           },
           expected: [
-            '/consumer/.hora/hora-skills-furo.json',
+            '/consumer/.hora/hora-skills-ort-furo.json',
           ],
         },
         {
           override: {
             linkedPaths: [
-              '/consumer/.hora/hora-skills-furo.json',
+              '/consumer/.hora/hora-skills-ort-furo.json',
             ],
           },
           expected: [
-            '/consumer/.hora/hora-skills-furo.json',
+            '/consumer/.hora/hora-skills-ort-furo.json',
           ],
         },
         {
@@ -1254,10 +1254,10 @@ describe('HoraSkillsCli', () => {
         {
           override: {
             linkedManifestFilePaths: [
-              '/consumer/.hora/hora-skills-furo.json',
+              '/consumer/.hora/hora-skills-ort-furo.json',
             ],
           },
-          expected: '/consumer/.hora/hora-skills-furo.json is reached through a symbolic link.',
+          expected: '/consumer/.hora/hora-skills-ort-furo.json is reached through a symbolic link.',
         },
       ]
 
@@ -1297,7 +1297,7 @@ describe('HoraSkillsCli', () => {
         {
           override: {
             distributedSkillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
           expected: '1 skills distributed',
@@ -1305,8 +1305,8 @@ describe('HoraSkillsCli', () => {
         {
           override: {
             distributedSkillNames: [
-              'hf-query-resolver',
-              'hf-stub-api',
+              'hof-query-resolver',
+              'hof-stub-api',
             ],
           },
           expected: '2 skills distributed',
@@ -1348,7 +1348,7 @@ describe('HoraSkillsCli', () => {
           override: {
             uninstallResult: {
               removedSkillNames: [
-                'hf-query-resolver',
+                'hof-query-resolver',
               ],
             },
           },

--- a/tests/__tests__/equip/SkillsInstaller.js
+++ b/tests/__tests__/equip/SkillsInstaller.js
@@ -75,7 +75,7 @@ describe('SkillsInstaller', () => {
           {
             input: {
               manifestFile: SkillsManifestFile.create({
-                filePath: '/consumer/.hora/hora-skills-furo.json',
+                filePath: '/consumer/.hora/hora-skills-ort-furo.json',
                 installationPath: '.claude/skills',
               }),
             },
@@ -83,7 +83,7 @@ describe('SkillsInstaller', () => {
           {
             input: {
               manifestFile: SkillsManifestFile.create({
-                filePath: '.hora/hora-skills-furo.json',
+                filePath: '.hora/hora-skills-ort-furo.json',
                 installationPath: 'tools/skills',
               }),
             },
@@ -144,7 +144,7 @@ describe('SkillsInstaller', () => {
             sourceDirectoryPath: '/package/dist/skills',
           },
           expected: {
-            filePath: '/consumer/.hora/hora-skills-furo.json',
+            filePath: '/consumer/.hora/hora-skills-ort-furo.json',
             installationPath: '.claude/skills',
           },
         },
@@ -155,7 +155,7 @@ describe('SkillsInstaller', () => {
             sourceDirectoryPath: '/package/dist/skills',
           },
           expected: {
-            filePath: '/tmp/.hora/hora-skills-furo.json',
+            filePath: '/tmp/.hora/hora-skills-ort-furo.json',
             installationPath: 'skills',
           },
         },
@@ -232,7 +232,7 @@ describe('SkillsInstaller', () => {
         expect(received)
           .toEqual([
             '.hora',
-            'hora-skills-furo.json',
+            'hora-skills-ort-furo.json',
           ])
       })
     })
@@ -266,14 +266,14 @@ describe('SkillsInstaller', () => {
             workingDirectoryPath: '/consumer',
             targetDirectoryPath: '/consumer/.claude/skills',
           },
-          expected: '/consumer/.hora/hora-skills-furo.json',
+          expected: '/consumer/.hora/hora-skills-ort-furo.json',
         },
         {
           input: {
             workingDirectoryPath: '/tmp',
             targetDirectoryPath: '/tmp/skills/',
           },
-          expected: '/tmp/.hora/hora-skills-furo.json',
+          expected: '/tmp/.hora/hora-skills-ort-furo.json',
         },
       ]
 
@@ -365,12 +365,12 @@ describe('SkillsInstaller', () => {
       const cases = [
         {
           input: {
-            skillName: 'hf-naming',
+            skillName: 'hof-naming',
           },
         },
         {
           input: {
-            skillName: 'hf-cp-table',
+            skillName: 'hof-cp-table',
           },
         },
         {
@@ -417,7 +417,7 @@ describe('SkillsInstaller', () => {
         },
         {
           input: {
-            skillName: 'hf-naming/SKILL.md',
+            skillName: 'hof-naming/SKILL.md',
           },
         },
         {
@@ -487,15 +487,15 @@ describe('SkillsInstaller', () => {
         {
           override: {
             removedSkillNames: [
-              'hf-cp-table',
+              'hof-cp-table',
             ],
             installedSkillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
           expected: {
             skillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
         },
@@ -537,18 +537,18 @@ describe('SkillsInstaller', () => {
         {
           override: {
             removedSkillNames: [
-              'hf-cp-table',
+              'hof-cp-table',
             ],
             installedSkillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
           expected: {
             removedSkillNames: [
-              'hf-cp-table',
+              'hof-cp-table',
             ],
             installedSkillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
         },
@@ -556,15 +556,15 @@ describe('SkillsInstaller', () => {
           override: {
             removedSkillNames: [],
             installedSkillNames: [
-              'hf-naming',
-              'hf-jsdoc',
+              'hof-naming',
+              'hof-jsdoc',
             ],
           },
           expected: {
             removedSkillNames: [],
             installedSkillNames: [
-              'hf-naming',
-              'hf-jsdoc',
+              'hof-naming',
+              'hof-jsdoc',
             ],
           },
         },
@@ -600,20 +600,20 @@ describe('SkillsInstaller', () => {
         {
           override: {
             recordedSkillNames: [
-              'hf-query-resolver',
-              'hf-stub-api',
+              'hof-query-resolver',
+              'hof-stub-api',
             ],
           },
           expected: [
             [
-              '/consumer/.claude/skills/hf-query-resolver',
+              '/consumer/.claude/skills/hof-query-resolver',
               {
                 recursive: true,
                 force: true,
               },
             ],
             [
-              '/consumer/.claude/skills/hf-stub-api',
+              '/consumer/.claude/skills/hof-stub-api',
               {
                 recursive: true,
                 force: true,
@@ -650,11 +650,11 @@ describe('SkillsInstaller', () => {
         {
           override: {
             recordedSkillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
           expected: [
-            'hf-query-resolver',
+            'hof-query-resolver',
           ],
         },
         {
@@ -690,28 +690,28 @@ describe('SkillsInstaller', () => {
           override: {
             recordedSkillNames: [],
             distributedSkillNames: [
-              'hf-query-resolver',
-              'hf-naming',
+              'hof-query-resolver',
+              'hof-naming',
             ],
             directoryNames: [
-              'hf-naming',
-              'hf-own-skill',
+              'hof-naming',
+              'hof-own-skill',
               'my-own-skill',
             ],
           },
           expected: [
-            'hf-naming',
+            'hof-naming',
           ],
         },
         {
           override: {
             recordedSkillNames: [],
             distributedSkillNames: [
-              'hf-query-resolver',
-              'hf-naming',
+              'hof-query-resolver',
+              'hof-naming',
             ],
             directoryNames: [
-              'hf-own-skill',
+              'hof-own-skill',
               'my-own-skill',
             ],
           },
@@ -749,12 +749,12 @@ describe('SkillsInstaller', () => {
           override: {
             recordedSkillNames: [
               '../../../canary',
-              'hf-naming',
+              'hof-naming',
             ],
           },
           expected: [
             [
-              '/consumer/.claude/skills/hf-naming',
+              '/consumer/.claude/skills/hof-naming',
               {
                 recursive: true,
                 force: true,
@@ -799,36 +799,36 @@ describe('SkillsInstaller', () => {
         {
           override: {
             recordedSkillNames: [
-              'hf-cp-table',
+              'hof-cp-table',
             ],
             distributedSkillNames: [
-              'hf-query-resolver',
-              'hf-naming',
+              'hof-query-resolver',
+              'hof-naming',
             ],
             directoryNames: [
-              'hf-naming',
-              'hf-own-skill',
+              'hof-naming',
+              'hof-own-skill',
             ],
           },
           expected: [
-            'hf-cp-table',
-            'hf-naming',
+            'hof-cp-table',
+            'hof-naming',
           ],
         },
         {
           override: {
             recordedSkillNames: [
-              'hf-naming',
+              'hof-naming',
             ],
             distributedSkillNames: [
-              'hf-naming',
+              'hof-naming',
             ],
             directoryNames: [
-              'hf-naming',
+              'hof-naming',
             ],
           },
           expected: [
-            'hf-naming',
+            'hof-naming',
           ],
         },
         {
@@ -836,7 +836,7 @@ describe('SkillsInstaller', () => {
             recordedSkillNames: [],
             distributedSkillNames: [],
             directoryNames: [
-              'hf-own-skill',
+              'hof-own-skill',
             ],
           },
           expected: [],
@@ -869,14 +869,14 @@ describe('SkillsInstaller', () => {
         {
           override: {
             recordedSkillNames: [
-              'hf-naming',
+              'hof-naming',
               '../../../canary',
             ],
             distributedSkillNames: [],
             directoryNames: [],
           },
           expected: [
-            'hf-naming',
+            'hof-naming',
           ],
         },
         {
@@ -885,7 +885,7 @@ describe('SkillsInstaller', () => {
               '..',
               '.',
               '',
-              'hf-naming/SKILL.md',
+              'hof-naming/SKILL.md',
             ],
             distributedSkillNames: [],
             directoryNames: [],
@@ -924,40 +924,40 @@ describe('SkillsInstaller', () => {
         {
           override: {
             distributedSkillNames: [
-              'hf-query-resolver',
-              'hf-jsdoc',
-              'hf-naming',
+              'hof-query-resolver',
+              'hof-jsdoc',
+              'hof-naming',
             ],
             directoryNames: [
-              'hf-naming',
-              'hf-own-skill',
+              'hof-naming',
+              'hof-own-skill',
               'my-own-skill',
             ],
           },
           expected: [
-            'hf-naming',
+            'hof-naming',
           ],
         },
         {
           override: {
             distributedSkillNames: [
-              'hf-query-resolver',
-              'hf-naming',
+              'hof-query-resolver',
+              'hof-naming',
             ],
             directoryNames: [
-              'hf-query-resolver',
-              'hf-naming',
+              'hof-query-resolver',
+              'hof-naming',
             ],
           },
           expected: [
-            'hf-query-resolver',
-            'hf-naming',
+            'hof-query-resolver',
+            'hof-naming',
           ],
         },
         {
           override: {
             distributedSkillNames: [
-              'hf-naming',
+              'hof-naming',
             ],
             directoryNames: [],
           },
@@ -994,11 +994,11 @@ describe('SkillsInstaller', () => {
           override: {
             dirents: [
               {
-                name: 'hf-cp-table',
+                name: 'hof-cp-table',
                 isDirectory: () => true,
               },
               {
-                name: 'hf-query-resolver',
+                name: 'hof-query-resolver',
                 isDirectory: () => true,
               },
               {
@@ -1008,8 +1008,8 @@ describe('SkillsInstaller', () => {
             ],
           },
           expected: [
-            'hf-cp-table',
-            'hf-query-resolver',
+            'hof-cp-table',
+            'hof-query-resolver',
           ],
         },
         {
@@ -1071,15 +1071,15 @@ describe('SkillsInstaller', () => {
       const cases = [
         {
           input: {
-            skillName: 'hf-query-resolver',
+            skillName: 'hof-query-resolver',
           },
-          expected: '/consumer/.claude/skills/hf-query-resolver',
+          expected: '/consumer/.claude/skills/hof-query-resolver',
         },
         {
           input: {
-            skillName: 'hf-naming',
+            skillName: 'hof-naming',
           },
-          expected: '/consumer/.claude/skills/hf-naming',
+          expected: '/consumer/.claude/skills/hof-naming',
         },
       ]
 
@@ -1105,15 +1105,15 @@ describe('SkillsInstaller', () => {
       const cases = [
         {
           input: {
-            skillName: 'hf-query-resolver',
+            skillName: 'hof-query-resolver',
           },
-          expected: '/package/dist/skills/hf-query-resolver',
+          expected: '/package/dist/skills/hof-query-resolver',
         },
         {
           input: {
-            skillName: 'hf-naming',
+            skillName: 'hof-naming',
           },
-          expected: '/package/dist/skills/hf-naming',
+          expected: '/package/dist/skills/hof-naming',
         },
       ]
 
@@ -1140,12 +1140,12 @@ describe('SkillsInstaller', () => {
         {
           override: {
             distributedSkillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
           expected: [
-            '/package/dist/skills/hf-query-resolver',
-            '/consumer/.claude/skills/hf-query-resolver',
+            '/package/dist/skills/hof-query-resolver',
+            '/consumer/.claude/skills/hof-query-resolver',
             {
               recursive: true,
             },
@@ -1154,12 +1154,12 @@ describe('SkillsInstaller', () => {
         {
           override: {
             distributedSkillNames: [
-              'hf-naming',
+              'hof-naming',
             ],
           },
           expected: [
-            '/package/dist/skills/hf-naming',
-            '/consumer/.claude/skills/hf-naming',
+            '/package/dist/skills/hof-naming',
+            '/consumer/.claude/skills/hof-naming',
             {
               recursive: true,
             },
@@ -1290,13 +1290,13 @@ describe('SkillsInstaller', () => {
           },
           input: {
             skillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
           expected: {
             version: '0.0.1',
             skillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
         },
@@ -1411,12 +1411,12 @@ describe('SkillsInstaller', () => {
         {
           override: {
             removedSkillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
           expected: {
             removedSkillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
         },

--- a/tests/__tests__/equip/SkillsManifestFile.js
+++ b/tests/__tests__/equip/SkillsManifestFile.js
@@ -10,17 +10,17 @@ describe('SkillsManifestFile', () => {
         const cases = [
           {
             input: {
-              filePath: '/tmp/app/.hora/hora-skills-furo.json',
+              filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
               installationPath: '.claude/skills',
             },
-            expected: '/tmp/app/.hora/hora-skills-furo.json',
+            expected: '/tmp/app/.hora/hora-skills-ort-furo.json',
           },
           {
             input: {
-              filePath: '.hora/hora-skills-furo.json',
+              filePath: '.hora/hora-skills-ort-furo.json',
               installationPath: 'tools/skills',
             },
-            expected: '.hora/hora-skills-furo.json',
+            expected: '.hora/hora-skills-ort-furo.json',
           },
         ]
 
@@ -36,14 +36,14 @@ describe('SkillsManifestFile', () => {
         const cases = [
           {
             input: {
-              filePath: '/tmp/app/.hora/hora-skills-furo.json',
+              filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
               installationPath: '.claude/skills',
             },
             expected: '.claude/skills',
           },
           {
             input: {
-              filePath: '.hora/hora-skills-furo.json',
+              filePath: '.hora/hora-skills-ort-furo.json',
               installationPath: 'tools/skills',
             },
             expected: 'tools/skills',
@@ -67,13 +67,13 @@ describe('SkillsManifestFile', () => {
       const cases = [
         {
           input: {
-            filePath: '/tmp/app/.hora/hora-skills-furo.json',
+            filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
             installationPath: '.claude/skills',
           },
         },
         {
           input: {
-            filePath: '.hora/hora-skills-furo.json',
+            filePath: '.hora/hora-skills-ort-furo.json',
             installationPath: 'tools/skills',
           },
         },
@@ -91,13 +91,13 @@ describe('SkillsManifestFile', () => {
       const cases = [
         {
           tally: {
-            filePath: '/tmp/app/.hora/hora-skills-furo.json',
+            filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
             installationPath: '.claude/skills',
           },
         },
         {
           tally: {
-            filePath: '.hora/hora-skills-furo.json',
+            filePath: '.hora/hora-skills-ort-furo.json',
             installationPath: 'tools/skills',
           },
         },
@@ -120,7 +120,7 @@ describe('SkillsManifestFile', () => {
     describe('when called as is', () => {
       test('should be fixed value', () => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -138,7 +138,7 @@ describe('SkillsManifestFile', () => {
     describe('when called as is', () => {
       test('should be fixed value', () => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -162,14 +162,14 @@ describe('SkillsManifestFile', () => {
               installations: {
                 '.claude/skills': {
                   skillNames: [
-                    'hf-query-resolver',
+                    'hof-query-resolver',
                   ],
                 },
               },
             },
           },
           expected: [
-            'hf-query-resolver',
+            'hof-query-resolver',
           ],
         },
         {
@@ -192,26 +192,26 @@ describe('SkillsManifestFile', () => {
               installations: {
                 '.claude/skills': {
                   skillNames: [
-                    'hf-naming',
+                    'hof-naming',
                   ],
                 },
                 'tools/skills': {
                   skillNames: [
-                    'hf-query-resolver',
+                    'hof-query-resolver',
                   ],
                 },
               },
             },
           },
           expected: [
-            'hf-naming',
+            'hof-naming',
           ],
         },
       ]
 
       test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -254,7 +254,7 @@ describe('SkillsManifestFile', () => {
               installations: {
                 'tools/skills': {
                   skillNames: [
-                    'hf-query-resolver',
+                    'hof-query-resolver',
                   ],
                 },
               },
@@ -276,7 +276,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('manifestHash: $override.manifestHash', ({ override }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -294,7 +294,7 @@ describe('SkillsManifestFile', () => {
       const cases = [
         {
           override: {
-            skillNames: 'hf-naming',
+            skillNames: 'hof-naming',
           },
         },
         {
@@ -310,7 +310,7 @@ describe('SkillsManifestFile', () => {
         {
           override: {
             skillNames: {
-              0: 'hf-naming',
+              0: 'hof-naming',
             },
           },
         },
@@ -318,7 +318,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('skillNames: $override.skillNames', ({ override }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -344,14 +344,14 @@ describe('SkillsManifestFile', () => {
         {
           override: {
             skillNames: [
-              'hf-naming',
+              'hof-naming',
               1,
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
           expected: [
-            'hf-naming',
-            'hf-query-resolver',
+            'hof-naming',
+            'hof-query-resolver',
           ],
         },
         {
@@ -359,10 +359,10 @@ describe('SkillsManifestFile', () => {
             skillNames: [
               null,
               {
-                skillName: 'hf-naming',
+                skillName: 'hof-naming',
               },
               [
-                'hf-naming',
+                'hof-naming',
               ],
             ],
           },
@@ -372,7 +372,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('skillNames: $override.skillNames', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -406,7 +406,7 @@ describe('SkillsManifestFile', () => {
               installations: {
                 '.claude/skills': {
                   skillNames: [
-                    'hf-naming',
+                    'hof-naming',
                   ],
                 },
               },
@@ -414,7 +414,7 @@ describe('SkillsManifestFile', () => {
           },
           expected: {
             skillNames: [
-              'hf-naming',
+              'hof-naming',
             ],
           },
         },
@@ -422,7 +422,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -459,7 +459,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('manifestHash: $override.manifestHash', ({ override }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -486,12 +486,12 @@ describe('SkillsManifestFile', () => {
               installations: {
                 '.claude/skills': {
                   skillNames: [
-                    'hf-naming',
+                    'hof-naming',
                   ],
                 },
                 'tools/skills': {
                   skillNames: [
-                    'hf-query-resolver',
+                    'hof-query-resolver',
                   ],
                 },
               },
@@ -500,12 +500,12 @@ describe('SkillsManifestFile', () => {
           expected: {
             '.claude/skills': {
               skillNames: [
-                'hf-naming',
+                'hof-naming',
               ],
             },
             'tools/skills': {
               skillNames: [
-                'hf-query-resolver',
+                'hof-query-resolver',
               ],
             },
           },
@@ -514,7 +514,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -546,7 +546,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('manifestHash: $override.manifestHash', ({ override }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -568,14 +568,14 @@ describe('SkillsManifestFile', () => {
       const cases = [
         {
           override: {
-            content: '{"version":"0.0.1","installations":{".claude/skills":{"skillNames":["hf-query-resolver"]}}}',
+            content: '{"version":"0.0.1","installations":{".claude/skills":{"skillNames":["hof-query-resolver"]}}}',
           },
           expected: {
             version: '0.0.1',
             installations: {
               '.claude/skills': {
                 skillNames: [
-                  'hf-query-resolver',
+                  'hof-query-resolver',
                 ],
               },
             },
@@ -594,7 +594,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('content: $override.content', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -613,7 +613,7 @@ describe('SkillsManifestFile', () => {
     describe('should be null when the manifest is absent', () => {
       test('when the file does not exist', () => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -643,7 +643,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('content: $override.content', ({ override }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -669,7 +669,7 @@ describe('SkillsManifestFile', () => {
           input: {
             version: '0.0.1',
             skillNames: [
-              'hf-query-resolver',
+              'hof-query-resolver',
             ],
           },
           override: {
@@ -680,7 +680,7 @@ describe('SkillsManifestFile', () => {
             installations: {
               '.claude/skills': {
                 skillNames: [
-                  'hf-query-resolver',
+                  'hof-query-resolver',
                 ],
               },
             },
@@ -707,7 +707,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('version: $input.version', ({ input, override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -732,14 +732,14 @@ describe('SkillsManifestFile', () => {
           input: {
             version: '0.0.1',
             skillNames: [
-              'hf-naming',
+              'hof-naming',
             ],
           },
           override: {
             installationHash: {
               'tools/skills': {
                 skillNames: [
-                  'hf-query-resolver',
+                  'hof-query-resolver',
                 ],
               },
             },
@@ -749,12 +749,12 @@ describe('SkillsManifestFile', () => {
             installations: {
               'tools/skills': {
                 skillNames: [
-                  'hf-query-resolver',
+                  'hof-query-resolver',
                 ],
               },
               '.claude/skills': {
                 skillNames: [
-                  'hf-naming',
+                  'hof-naming',
                 ],
               },
             },
@@ -764,7 +764,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('version: $input.version', ({ input, override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -789,14 +789,14 @@ describe('SkillsManifestFile', () => {
           input: {
             version: '0.0.2',
             skillNames: [
-              'hf-naming',
+              'hof-naming',
             ],
           },
           override: {
             installationHash: {
               '.claude/skills': {
                 skillNames: [
-                  'hf-cp-table',
+                  'hof-cp-table',
                 ],
               },
             },
@@ -806,7 +806,7 @@ describe('SkillsManifestFile', () => {
             installations: {
               '.claude/skills': {
                 skillNames: [
-                  'hf-naming',
+                  'hof-naming',
                 ],
               },
             },
@@ -816,7 +816,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('version: $input.version', ({ input, override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -848,15 +848,15 @@ describe('SkillsManifestFile', () => {
               installations: {
                 '.claude/skills': {
                   skillNames: [
-                    'hf-query-resolver',
+                    'hof-query-resolver',
                   ],
                 },
               },
             },
           },
           expected: [
-            '/tmp/app/.hora/hora-skills-furo.json',
-            '{\n  "version": "0.0.1",\n  "installations": {\n    ".claude/skills": {\n      "skillNames": [\n        "hf-query-resolver"\n      ]\n    }\n  }\n}\n',
+            '/tmp/app/.hora/hora-skills-ort-furo.json',
+            '{\n  "version": "0.0.1",\n  "installations": {\n    ".claude/skills": {\n      "skillNames": [\n        "hof-query-resolver"\n      ]\n    }\n  }\n}\n',
           ],
         },
         {
@@ -867,7 +867,7 @@ describe('SkillsManifestFile', () => {
             },
           },
           expected: [
-            '/tmp/app/.hora/hora-skills-furo.json',
+            '/tmp/app/.hora/hora-skills-ort-furo.json',
             '{\n  "version": null,\n  "installations": {}\n}\n',
           ],
         },
@@ -875,7 +875,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('version: $input.manifestHash.version', ({ input, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -912,7 +912,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('version: $input.manifestHash.version', ({ input, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -947,7 +947,7 @@ describe('SkillsManifestFile', () => {
             },
           },
           expected: [
-            '/tmp/app/.hora/hora-skills-furo.json',
+            '/tmp/app/.hora/hora-skills-ort-furo.json',
             {
               force: true,
             },
@@ -957,7 +957,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -986,7 +986,7 @@ describe('SkillsManifestFile', () => {
                 },
                 'tools/skills': {
                   skillNames: [
-                    'hf-query-resolver',
+                    'hof-query-resolver',
                   ],
                 },
               },
@@ -998,7 +998,7 @@ describe('SkillsManifestFile', () => {
               installations: {
                 'tools/skills': {
                   skillNames: [
-                    'hf-query-resolver',
+                    'hof-query-resolver',
                   ],
                 },
               },
@@ -1009,7 +1009,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('installations: $override.manifestHash.installations', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -1034,7 +1034,7 @@ describe('SkillsManifestFile', () => {
     describe('should do nothing when no manifest is readable', () => {
       test('when the manifest is absent', () => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 
@@ -1071,7 +1071,7 @@ describe('SkillsManifestFile', () => {
               },
               'tools/skills': {
                 skillNames: [
-                  'hf-query-resolver',
+                  'hof-query-resolver',
                 ],
               },
             },
@@ -1079,7 +1079,7 @@ describe('SkillsManifestFile', () => {
           expected: {
             'tools/skills': {
               skillNames: [
-                'hf-query-resolver',
+                'hof-query-resolver',
               ],
             },
           },
@@ -1104,7 +1104,7 @@ describe('SkillsManifestFile', () => {
 
       test.each(cases)('installationHash: $override.installationHash', ({ override, expected }) => {
         const manifestFile = SkillsManifestFile.create({
-          filePath: '/tmp/app/.hora/hora-skills-furo.json',
+          filePath: '/tmp/app/.hora/hora-skills-ort-furo.json',
           installationPath: '.claude/skills',
         })
 


### PR DESCRIPTION
# Why

* Close #26

# How

* Renames the package from `@openreachtech/hora-skills-furo` to `@openreachtech/hora-skills-ort-furo`, along with the URLs `package.json` declares — the repository itself was renamed on GitHub
* Renames the command with it: `bin`, the file `lib/equip/hora-skills-ort-furo.js`, the usage text, and the record an installation writes at `.hora/hora-skills-ort-furo.json`
* The sample skill names inside the equip tests carry the new prefix as well: they are fixtures of the files this pull request moves, and the prefix itself is renamed in #25
* The command file, `package.json` and the tests move together because a `bin` naming a file that is not there installs nothing, and the tests assert the path of the record

`hora-skills-ort-furo list` prints the 46 skills this library distributes. The skill prefix is renamed separately.
