### PR TITLE
Add component skills description

### DIFF
--- a/kit/skills/hof-cp-button/SKILL.md
+++ b/kit/skills/hof-cp-button/SKILL.md
@@ -20,6 +20,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - You need a menu of multiple actions behind a single trigger → use `hof-cp-dropdown-menu` (its default trigger slot is already `FuroButton`-styled; don't nest a separate `FuroButton` inside it unless overriding the trigger content).
@@ -40,10 +48,10 @@ this skill was written.
 | --- | --- | --- | --- |
 | `variant` | `FuroButtonVariant` | `'default'` | Visual style preset. Six variants exist: default, secondary, destructive, outline, ghost, link. |
 | `size` | `FuroButtonSize` | `'default'` | Size preset. Four sizes exist: default, sm, lg, and a square icon size. |
-| `disabled` | `boolean` | `false` | Disables interaction; also respects a fallthrough `disabled` attribute. |
+| `disabled` | `boolean` | `false` | Disables interaction; also respects a fallthrough `disabled` attribute. With `asChild`, that attribute is consumed rather than forwarded to the child. |
 | `loading` | `boolean` | `false` | Shows the loading slot and blocks the click emit. |
-| `asChild` | `boolean` | `false` | Merge props and behavior onto a single child element. |
-| `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | Native button type when not `asChild`. |
+| `asChild` | `boolean` | `false` | Merge props and behavior onto a single child element. `disabled` and `type` are **not** bound on that child. |
+| `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | Native button type. Withheld with `asChild`, so write `type` on the child itself. |
 
 ## Events
 
@@ -100,6 +108,34 @@ With `asChild` composition onto an anchor:
 </template>
 ```
 
+## `asChild`: the attribute contract
+
+The slot child is rendered as the element itself, so `disabled` and `type` are
+not bound on it — whether they arrive through the `parcel` or as a fallthrough
+attribute. `<a>` has no `disabled` attribute, and forcing `type="button"` would
+override a child `<button>`'s own semantics. Write `type` on the child.
+
+`class`, `aria-disabled`, `aria-busy` and every other fallthrough attribute do
+reach the child. The child's own props win over the button's, except event
+handlers, which run alongside — the button's first.
+
+## `asChild`: a disabled child cannot be activated
+
+While `disabled` or `loading` is true the child also gets `tabindex="-1"`, and
+the default action of `click` and of Enter / Space `keydown` is prevented — so a
+"disabled" `<a href>`, `RouterLink` or `NuxtLink` does not navigate.
+
+Pass an element child, or a component that binds `$attrs` on its root. A
+component with `inheritAttrs: false` that never re-binds `$attrs` receives none
+of this — no `tabindex`, no `aria-disabled`, not even the class — and neither
+guard runs.
+
+## Appearance
+
+The `outline` variant's border reads `--color-input`, the stronger of the
+library's two border tiers. The loading spinner stops under
+`prefers-reduced-motion: reduce`, while `loading` still blocks the click emit.
+
 ## Rules (per project conventions)
 
 - `FuroButton` is an action trigger, not a form-control — it carries no
@@ -111,3 +147,11 @@ With `asChild` composition onto an anchor:
 - Keep the decision of what a click actually does (submit a form, call a
   Submitter, navigate) in the page/component Context as a named method
   (e.g. `onClickDelete`); the template should only forward `$event` to it.
+- With `parcel.asChild`, pass an element (or a component that binds `$attrs` on
+  its root) and write `type` on that child. Never rely on a disabled `asChild`
+  link staying navigable.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-checkbox-toggle/SKILL.md
+++ b/kit/skills/hof-cp-checkbox-toggle/SKILL.md
@@ -27,6 +27,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Grouped, mutually-exclusive or multi-select toolbar buttons → use `hof-cp-toggle-group` instead of wiring multiple `FuroToggle` by hand.
@@ -88,6 +96,13 @@ this skill was written.
 - `FuroToggle`:
   - `default` (scoped props: `{ pressed }`) — toggle label or icon. `pressed` reflects the current state for conditional content.
 
+## Appearance
+
+This component's control boundary reads `--color-input`, the stronger of the
+library's two border tiers. If your app pinned a lighter edge, override
+`--color-input` from the app side — see the library token skill
+(`hof-lib-tokens`).
+
 ## Usage
 
 ```vue
@@ -148,3 +163,8 @@ export default {
 - Put the effect of a `FuroToggle` press (e.g. applying a formatting command,
   flipping a setting) in the page/component Context's `on{Toggle}Change`
   method, not inline in the template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-collapsible/SKILL.md
+++ b/kit/skills/hof-cp-collapsible/SKILL.md
@@ -22,6 +22,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Content should be hidden behind a modal/drawer overlay rather than expand
@@ -98,6 +106,11 @@ this skill was written.
 | --- | --- | --- |
 | `header` | `{ option, expanded }` | Header content for a section. Defaults to `option.label` (or `option.value`). |
 | `content` | `{ option, expanded }` | Body content revealed when the section is open. |
+
+## Reduced motion
+
+`FuroCollapsible`'s and `FuroAccordion`'s open/close animation stops under `prefers-reduced-motion: reduce`. Do not add an app-level
+guard on top of it.
 
 ## Usage
 
@@ -176,3 +189,8 @@ export default {
   `FuroCollapsible` / `FuroAccordion` exports.
 - Put section data (`options`) and open-state change handling in the
   page/component Context, not inline in the template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-control-block/SKILL.md
+++ b/kit/skills/hof-cp-control-block/SKILL.md
@@ -20,6 +20,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - You need the actual input control, not just the label/error frame — pick the atom itself: `hof-cp-text-field`, `hof-cp-textarea`, `hof-cp-checkbox-toggle`, `hof-cp-select`, `hof-cp-date-time`.
@@ -49,7 +57,30 @@ None. `FuroControlBlock` emits nothing — the slotted control owns its own
 
 ## Slots
 
-- `default` — the control to frame. Pass the same id as the parcel `controlId` so label `for` resolves.
+| Slot | Scoped props | Description |
+| --- | --- | --- |
+| `default` | `{ errorId: string \| null }` | The control to frame. Pass the same id as the parcel `controlId` so label `for` resolves, and bind `errorId` onto the control's `aria-describedby` so the error text is announced again when focus returns to the field. |
+
+### `errorId`
+
+The block cannot set attributes on a slot child, so it hands the id of its error
+region to the default slot and you bind it on the control you own.
+
+- `` `${controlId}-error` `` when the parcel carries a `controlId`, otherwise
+  `` `${id}-error` `` from an `id` written on the block.
+- `null` while the block is valid, or when it has neither id. Vue drops an
+  attribute bound to `null`, so no guard is needed on your side and
+  `aria-describedby` never points at an element that is not rendered.
+- Nothing is generated: with neither id you get `null`, not an invented value.
+  A non-string `id` is refused rather than coerced.
+- It ships untyped — a TypeScript consumer destructuring it gets `any`.
+
+## Fallthrough attributes
+
+`class` and `style` compose onto the root. Every other DOM attribute you write
+on the component — `id`, `aria-*`, `data-*` — lands on its rendered root
+element, so a `<label for>` resolves and an `aria-describedby` reference points
+at something real.
 
 ## Usage
 
@@ -77,11 +108,14 @@ export default {
       required: true,
     }"
   >
-    <FuroTextField
-      id="full-name"
-      v-model:value="form.fullName"
-      :parcel="{ invalid: context.hasFullNameError() }"
-    />
+    <template #default="{ errorId }">
+      <FuroTextField
+        id="full-name"
+        v-model:value="form.fullName"
+        :parcel="{ invalid: context.hasFullNameError() }"
+        :aria-describedby="errorId"
+      />
+    </template>
   </FuroControlBlock>
 </template>
 ```
@@ -114,3 +148,12 @@ Horizontal orientation:
   `FuroControlBlock` export.
 - Compute `errorMessages` and `required` in the page/component Context
   (e.g. a `{field}ErrorMessages` getter), not inline in the template.
+- Take the `errorId` scoped slot prop and bind it to the slotted control's
+  `aria-describedby` whenever the block can render error messages. `role="alert"`
+  announces a message as it appears; `aria-describedby` is what re-announces it
+  when focus returns to the field.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-date-time/SKILL.md
+++ b/kit/skills/hof-cp-date-time/SKILL.md
@@ -23,6 +23,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Plain single-line text/number input with no calendar/time semantics → use `hof-cp-text-field` instead.
@@ -151,6 +159,18 @@ No slots — the manifest lists an empty `slots` array for this component.
 
 No slots — the manifest lists an empty `slots` array for this component.
 
+## Fallthrough attributes
+
+`class` and `style` compose onto the root. Every other DOM attribute you write
+on the component — `id`, `aria-*`, `data-*` — lands on its rendered root
+element, so a `<label for>` resolves and an `aria-describedby` reference points
+at something real.
+
+## Reduced motion
+
+`FuroDatePicker`'s popover animation stops under `prefers-reduced-motion: reduce`. Do not add an app-level
+guard on top of it.
+
 ## Usage
 
 ```vue
@@ -218,3 +238,8 @@ With a label/hint/error wrapper:
   `FuroTimeField` yourself whenever the underlying data model is a single
   combined timestamp — it keeps the calendar single-sourced and normalizes
   the wire format for you.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-dialog/SKILL.md
+++ b/kit/skills/hof-cp-dialog/SKILL.md
@@ -27,6 +27,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Small, click-anchored floating panel that doesn't need to block the page (inline edit, action panel) → use `hof-cp-popover` (`FuroPopover`), not a non-modal `FuroDialog`.
@@ -151,6 +159,13 @@ All three take a single `parcel` prop — no other props.
 | `footer` (scoped: `{ close }`) | Footer region (e.g. action buttons). Receives a `close()` slot prop. |
 | `close` | Content of the built-in close button (defaults to ✕). |
 
+## Fallthrough attributes
+
+`class` and `style` compose onto the root. Every other DOM attribute you write
+on the component — `id`, `aria-*`, `data-*` — lands on its wrapper
+element, so a `<label for>` resolves and an `aria-describedby` reference points
+at something real.
+
 ## Usage
 
 ```vue
@@ -228,3 +243,8 @@ export default {
 - Keep business logic (what happens on confirm/cancel/close, what data the
   dialog body submits) in the page/component Context, not inline in the
   template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-dropdown-menu/SKILL.md
+++ b/kit/skills/hof-cp-dropdown-menu/SKILL.md
@@ -22,6 +22,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - A single one-shot action with no menu of choices → use `hof-cp-button` directly instead.
@@ -67,6 +75,13 @@ checkbox rows yourself and pass it back in via `parcel.options`.
 | `trigger` | Native button labeled "Menu" (`FuroButton`-compatible styling). Override with label content. |
 | `option-label` | Override row label rendering. Scoped props: `{ option, index }`. Defaults to `option.label` text. |
 | `default` | Append custom menu content (advanced). |
+
+## Fallthrough attributes
+
+`class` and `style` compose onto the root. Every other DOM attribute you write
+on the component — `id`, `aria-*`, `data-*` — lands on its wrapper
+element, so a `<label for>` resolves and an `aria-describedby` reference points
+at something real.
 
 ## Usage
 
@@ -119,3 +134,8 @@ With a checkbox row whose checked state is owned by the Context:
 - Build the `options` array and every `on...` handler (`onSelectRowAction`,
   `onToggleColumnVisibility`, etc.) in the page/component Context, not
   inline in the template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-editable-field/SKILL.md
+++ b/kit/skills/hof-cp-editable-field/SKILL.md
@@ -22,6 +22,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - The value is always in edit mode (a normal form field, no preview state) → use `hof-cp-text-field` or `hof-cp-textarea` directly instead.
@@ -74,6 +82,12 @@ onto this component; it does not exist.
 | `submit-trigger` | Inside the editor actions; visible while editing. Same scoped props as `preview`. |
 | `cancel-trigger` | Inside the editor actions; visible while editing. Same scoped props as `preview`. |
 | `undo-trigger` | Shown when `showUndoChange` and the value changed since mount. Same scoped props as `preview`. |
+
+## A consumer `id` does not land
+
+An `id` written on `<FuroEditableField>` is not surfaced in the rendered DOM. Do not
+hang a `<label for>`, an `aria-*` reference, or an E2E hook off it — put it on a
+wrapper element you own, or on the content you pass through a slot.
 
 ## Usage
 
@@ -134,3 +148,8 @@ With a custom `#editor` slot for a non-text control:
 - Keep commit/validation/undo-decision logic in the page/component Context,
   not inline in the template — the template should only call a Context
   method from `@commit-value`.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-editor/SKILL.md
+++ b/kit/skills/hof-cp-editor/SKILL.md
@@ -21,6 +21,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Plain multi-line text with no formatting (comment box, description field)
@@ -72,6 +80,13 @@ this skill was written.
 | `toolbar-end` | `{ command, editor }` | Custom controls appended to the toolbar. |
 | `attachments` | `{ attachedFiles, remove, isEditable }` | Render the attachment UI. `remove` is `({ index }) => void`. |
 | `footer` | — | Content rendered below the editor (e.g. submit row). |
+
+## Fallthrough attributes
+
+`class` and `style` compose onto the root. Every other DOM attribute you write
+on the component — `id`, `aria-*`, `data-*` — lands on its rendered root
+element, so a `<label for>` resolves and an `aria-describedby` reference points
+at something real.
 
 ## Usage
 
@@ -132,3 +147,8 @@ With attachments and a footer submit row:
 - Keep mention search, image upload, and commit/validation logic in the
   page/component Context (`on{Field}Commit`, `search...`, `upload...` style
   methods), not inline in the template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-empty-state/SKILL.md
+++ b/kit/skills/hof-cp-empty-state/SKILL.md
@@ -24,6 +24,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - The region is still loading (request in flight), not empty or failed → use `app-avatar` (`FuroSkeleton`) instead.
@@ -82,6 +90,11 @@ this skill was written.
 | --- | --- | --- |
 | `icon` | — | Leading icon or illustration above the title. |
 | `action` | — | Action controls (for example a retry button) below the text. |
+
+## Appearance
+
+`FuroErrorState`'s glyph reads `--color-error-text`, the tier the error family
+is read at when it carries no surface — not the family's fill.
 
 ## Usage
 
@@ -146,3 +159,8 @@ export default {
   `hasFetchError`, `hasNoMembers`) for the template to branch on with
   `v-if`/`v-else-if`, rather than embedding fetch-result inspection in the
   template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-popover/SKILL.md
+++ b/kit/skills/hof-cp-popover/SKILL.md
@@ -22,6 +22,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Needs a menu of discrete actions (not a click-anchored surface with slot content) → use `hof-cp-dropdown-menu`.
@@ -86,6 +94,12 @@ Both components take a single `parcel` prop — no other props.
 | `trigger` | The element the tooltip is anchored to. Focusable by default (rendered as a button). |
 | `content` | Rich tooltip body. Falls back to `parcel.text` when omitted. |
 
+## A consumer `id` does not land
+
+An `id` written on `<FuroPopover>` is not surfaced in the rendered DOM. Do not
+hang a `<label for>`, an `aria-*` reference, or an E2E hook off it — put it on a
+wrapper element you own, or on the content you pass through a slot.
+
 ## Usage
 
 ```vue
@@ -144,3 +158,8 @@ export default {
   etc.) — only the public `FuroPopover` / `FuroTooltip` exports.
 - Keep business logic (what happens on open/close, what the popover form
   submits) in the page/component Context, not inline in the template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-select/SKILL.md
+++ b/kit/skills/hof-cp-select/SKILL.md
@@ -26,6 +26,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Free-form text entry, not a pick from a list → use `hof-cp-text-field`.
@@ -71,7 +79,7 @@ this skill was written.
 
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
-| `value` | `FuroAutocompleteOption \| FuroAcceptableValue \| Array \| null` | — | Controlled selection; synced to the internal value, with fallthrough `value` as fallback. |
+| `value` | `FuroAutocompleteOption \| FuroAcceptableValue \| Array<FuroAutocompleteOption \| FuroAcceptableValue> \| null` | — | Controlled selection; synced to the internal value, with fallthrough `value` as fallback. |
 | `options` | `Array<FuroAutocompleteOption \| FuroAcceptableValue>` | `[]` | List rows (groups and leaves). |
 | `placeholder` | `string` | `'Select an option'` | Input placeholder. |
 | `loading` | `boolean` | `false` | Input spinner; filtered list returns empty and the empty state is suppressed. |
@@ -106,7 +114,7 @@ this skill was written.
 | Event | Payload | Fires when |
 | --- | --- | --- |
 | `change-value` | `AutocompleteEmitPayload` | Select option, select-all, clear, or chip remove. |
-| `update:value` | Option object, array, or null | Same gesture as `change-value`; suitable for `v-model:value`. |
+| `update:value` | `FuroAutocompleteOption \| FuroAcceptableValue \| Array<FuroAutocompleteOption \| FuroAcceptableValue> \| null` | Same gesture as `change-value`; suitable for `v-model:value`. |
 | `search-keyword` | `string` | After debounce while the popover is open; also `''` on clear. |
 | `create-option` | `AutocompleteEmitPayload` | Select the create row (creatable); read the typed value via `extractTrimmedSearchKeyword()`. |
 
@@ -138,6 +146,20 @@ fires at the selection point.
 | `empty` | `{ searchKeyword, loading }` | Shown when the filtered list is empty and not loading; defaults to `emptyText`. |
 | `loading` | `{ searchKeyword }` | Spinner shown in the list. |
 | `create-option` | `{ searchKeyword }` | `createOptionText` with `{keyword}` replaced; shown only when `creatable` and no exact match. |
+
+## Fallthrough attributes on `FuroSelect`
+
+Attributes written on `<FuroSelect>` are split by where they belong, because the
+component's state root renders no element of its own:
+
+| Attribute | Lands on |
+| --- | --- |
+| `id`, `aria-label`, `aria-labelledby`, `aria-describedby`, `data-*`, `title`, `tabindex`, … | the trigger — the `<button role="combobox">`, so a `<label for>` resolves |
+| `name`, `required`, `disabled`, `value`, `autocomplete`, `by` | the control itself; behaviour unchanged |
+| `class`, `style` | the wrapper |
+
+`triggerParcel` is applied after fallthrough, so an attribute declared there wins
+over the same one arriving by fallthrough.
 
 ## Usage
 
@@ -206,3 +228,11 @@ export default {
   create-option persistence in the page/component Context
   (`on{Field}SearchKeyword`, `on{Field}CreateOption` style methods), not
   inline in the template.
+- Put `id` and `aria-*` on `<FuroSelect>` as plain fallthrough attributes and
+  let the split route them to the trigger — do not reach for `triggerParcel` to
+  place an `id`, and do not put `name` / `required` / `disabled` there.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-splitter/SKILL.md
+++ b/kit/skills/hof-cp-splitter/SKILL.md
@@ -27,6 +27,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Grouping buttons/toggles into one keyboard-navigable toolbar → use `hof-cp-toggle-group` (`FuroToolBar`) instead; its separators between control groups are the same `FuroSeparator`, but the surrounding container is not `FuroSplitter`.
@@ -114,6 +122,12 @@ this skill was written.
 
 `FuroSeparator` has no documented slots in the manifest.
 
+## A consumer `id` does not land
+
+An `id` written on `<FuroSplitter>` is not surfaced in the rendered DOM. Do not
+hang a `<label for>`, an `aria-*` reference, or an E2E hook off it — put it on a
+wrapper element you own, or on the content you pass through a slot.
+
 ## Usage
 
 ```vue
@@ -171,3 +185,8 @@ A separator used purely for visual division, unrelated to the splitter:
   `FuroSeparator` exports.
 - Put layout-persistence logic (e.g. saving `payload.layout` to a user
   preference) in the page/component Context, not inline in the template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-stepper/SKILL.md
+++ b/kit/skills/hof-cp-stepper/SKILL.md
@@ -20,6 +20,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Mutually exclusive content panels the user switches between freely (not a
@@ -60,6 +68,13 @@ this skill was written.
 | `<value>` (or `<slotName>`) | `{ value, step }` | Panel content for the matching step. One slot per step, keyed by the step's `value` (or its `slotName` override). |
 | `indicator-<value>` | `{ step, value, completed }` | Custom indicator content. When omitted, shows a check icon when completed, else the step number. |
 | `title-<value>` | `{ value }` | Custom title content. When omitted, the title shows `title`. |
+
+## Appearance
+
+This component's control boundary reads `--color-input`, the stronger of the
+library's two border tiers. If your app pinned a lighter edge, override
+`--color-input` from the app side — see the library token skill
+(`hof-lib-tokens`).
 
 ## Usage
 
@@ -130,3 +145,8 @@ Indicator-strip-only mode, where the step content lives in the page itself:
 - Keep the `steps` array and step-transition/validation logic (e.g. whether
   a step may be left) in the page/component Context, not inline in the
   template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-table/SKILL.md
+++ b/kit/skills/hof-cp-table/SKILL.md
@@ -23,6 +23,14 @@ Read the manifest before writing markup if you need to confirm this
 information is still current — the library may have added props/events since
 this skill was written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Non-tabular list of cards/rows with no columns/sorting needs → a plain `v-for` list is simpler than forcing it into `FuroTable`.
@@ -122,6 +130,17 @@ inspecting the component source shows each entry carries at least `field` and
 | `ellipsis` | — | Content of the gap marker (defaults to a three-dots icon). |
 | `page` | `{ page }` | Custom content for each page entry. Rendered via as-child, so the slot may supply an anchor for SEO — the click still drives `page:change`. |
 
+## Appearance and motion
+
+- The error row reads `--color-destructive-text`, the tier the destructive
+  family is read at when it carries no surface. The column-resize bar reads
+  `--color-input`, the interactive border tier.
+- The skeleton shimmer and the loading spinner stop under
+  `prefers-reduced-motion: reduce`.
+- `FuroTableVirtual` takes `{ itemSize, height, overscan?, endThreshold? }`.
+  `endThreshold` (default `8`) is how close to the loaded end a downward scroll
+  must get before more rows are requested.
+
 ## Usage
 
 ```vue
@@ -195,3 +214,8 @@ export default {
   presentational and holds no GraphQL, router, or fetch logic of its own —
   that responsibility belongs to the Context per the parent-component data
   flow policy.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-tabs/SKILL.md
+++ b/kit/skills/hof-cp-tabs/SKILL.md
@@ -21,6 +21,14 @@ Read the manifest before writing markup if you need to confirm it's still
 current — the library may have added props/events since this skill was
 written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Show/hide a single region without a trigger row of labeled tabs → use `hof-cp-collapsible`.
@@ -66,6 +74,11 @@ if the manifest doesn't expand this type.
 | --- | --- | --- |
 | `<value>` (or `<slotName>`) | — | Panel content for the matching tab. One slot per tab, keyed by the tab's `value` (or its `slotName` override). |
 | `label-<value>` | `{ value, label }` | Custom trigger content for the matching tab. When omitted, the trigger shows `label`. |
+
+## Reduced motion
+
+The active-tab indicator slide stops under `prefers-reduced-motion: reduce`. Do not add an app-level
+guard on top of it.
 
 ## Usage
 
@@ -135,3 +148,8 @@ Navigation-menu-only mode (router-driven, no panels):
 - Keep tab-change side effects (e.g. lazy-loading a panel's data, router
   navigation in menu-only mode) in the page/component Context's
   `onTabChange`-style method, not inline in the template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-text-field/SKILL.md
+++ b/kit/skills/hof-cp-text-field/SKILL.md
@@ -28,6 +28,14 @@ Read the manifest before writing markup if you need to confirm it's still
 current — the library may have added props/events since this skill was
 written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Multi-line text (comments, descriptions) → use `hof-cp-textarea` (`FuroTextarea`) instead.
@@ -147,6 +155,13 @@ no `v-model:value` support for this component.
   - `decrement` (scoped props: `{ value }`) — replaces the default decrement icon. Default: `ph:minus`.
   - `increment` (scoped props: `{ value }`) — replaces the default increment icon. Default: `ph:plus`.
 
+## Appearance
+
+This component's control boundary reads `--color-input`, the stronger of the
+library's two border tiers. If your app pinned a lighter edge, override
+`--color-input` from the app side — see the library token skill
+(`hof-lib-tokens`).
+
 ## Usage
 
 ```vue
@@ -225,3 +240,8 @@ export default {
   `FuroFileField` exports.
 - Put commit/validation logic in the page/component Context
   (`on{Field}Commit` style method), not inline in the template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-textarea/SKILL.md
+++ b/kit/skills/hof-cp-textarea/SKILL.md
@@ -17,6 +17,14 @@ Read the manifest before writing markup if you need to confirm it's still
 current — the library may have added props/events since this skill was
 written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - Single-line input (name, email, number, password, file) → use `hof-cp-text-field` (`FuroTextField` and its typed variants) instead.
@@ -45,6 +53,13 @@ written.
 
 `TextareaEmitPayload` exposes the same trimmed-value and emptiness helpers as
 `FuroTextField`'s payload — read the payload class if you need those.
+
+## Appearance
+
+This component's control boundary reads `--color-input`, the stronger of the
+library's two border tiers. If your app pinned a lighter edge, override
+`--color-input` from the app side — see the library token skill
+(`hof-lib-tokens`).
 
 ## Usage
 
@@ -95,3 +110,8 @@ With a label/hint/error wrapper:
   `FuroTextarea` export.
 - Put commit/validation logic in the page/component Context
   (`on{Field}Commit` style method), not inline in the template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-toast/SKILL.md
+++ b/kit/skills/hof-cp-toast/SKILL.md
@@ -25,6 +25,14 @@ Read the manifest before writing markup if you need to confirm it's still
 current — the library may have added props/events since this skill was
 written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - A persistent inline validation error under a field → use
@@ -100,6 +108,12 @@ event wiring from the consumer.
 `FuroToaster` declares no slots — customize toast content per call through
 the fields passed to `toast.show({ ... })` (`title`, `description`, `type`,
 `actions`, …), not through slot markup.
+
+## A consumer `id` does not land
+
+An `id` written on `<FuroToast>` is not surfaced in the rendered DOM. Do not
+hang a `<label for>`, an `aria-*` reference, or an E2E hook off it — put it on a
+wrapper element you own, or on the content you pass through a slot.
 
 ## Usage
 
@@ -197,3 +211,8 @@ export default {
   `toast` helper (`toast.show`/`update`/`hide`/`clear`/`configure`) rather
   than reaching for `ToastQueue` directly, unless you specifically need to
   build a custom queue consumer.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.

--- a/kit/skills/hof-cp-toggle-group/SKILL.md
+++ b/kit/skills/hof-cp-toggle-group/SKILL.md
@@ -22,6 +22,14 @@ Read the manifest before writing markup if you need to confirm it's still
 current — the library may have added props/events since this skill was
 written.
 
+Each manifest record also carries a `types` array beside `slots`. When a prop,
+`parcel` field, or event payload names a nested type
+(`Array<FuroSelectOption>`, `FuroTableColumn`, …), read that name from the same
+record's `types` array — each entry carries the authored `definition` plus a
+parsed `fields` list (`name`, `type`, `required`) for an object shape, or
+`values` for a string union. Read the shape from the manifest, not from
+component source.
+
 ## When NOT to use
 
 - A single boolean on/off control, not a group of options → use `hof-cp-checkbox-toggle` instead.
@@ -88,6 +96,13 @@ written.
 | Slot | Scoped props | Description |
 | --- | --- | --- |
 | `default` | — | The controls to group — buttons, toggles, toggle groups, separators. |
+
+## Appearance
+
+This component's control boundary reads `--color-input`, the stronger of the
+library's two border tiers. If your app pinned a lighter edge, override
+`--color-input` from the app side — see the library token skill
+(`hof-lib-tokens`).
 
 ## Usage
 
@@ -174,3 +189,8 @@ export default {
   only the public `FuroToggleGroup` / `FuroToolBar` exports.
 - Put selection-change handling and business logic in the page/component
   Context (`on{Field}Change` style method), not inline in the template.
+- Pass only the `parcel` keys this skill lists. A component reads the keys it
+  names and ignores the rest, so a mistyped key changes nothing and reports
+  nothing. Some components warn in development through Vue's warning channel,
+  naming the unknown key and the accepted ones — but not every component does,
+  so check a key against the manifest rather than trusting silence.


### PR DESCRIPTION
# Why

* Close #issue 1489
- Update the 20 component skills against what the library actually ships now.
  Several of them stated the opposite of current behaviour, so an agent
  following them would have written markup that does not work.
- Per component: where a fallthrough `id` / `aria-*` lands, and which
  components still do not surface one at all.
- The control block hands an `errorId` to its default slot; the usage example
  now wires it onto the control's `aria-describedby`.
- The button's `asChild` attribute contract, and the guard that stops a
  disabled child from being activated.
- Each manifest record carries a `types` array, so a nested type shape is read
  from the manifest instead of from component source.
- Notes on the interactive border tier and the `prefers-reduced-motion` guards,
  plus corrected option types on the select and the `endThreshold` field on the
  table.

# How

* docs: record the asChild attribute contract and activation guard on Button
* docs: record the errorId slot prop and root fallthrough on ControlBlock
* docs: record the fallthrough split and the corrected option types on Select
* docs: record the root fallthrough and reduced-motion guard on the date pickers
* docs: record the root fallthrough on Editor
* docs: record the wrapper fallthrough on the dialog overlays
* docs: record the wrapper fallthrough on DropdownMenu
* docs: record that a consumer id does not land on the toasts
* docs: record that a consumer id does not land on Popover
* docs: record that a consumer id does not land on Splitter
* docs: record that a consumer id does not land on EditableField
* docs: record the error row tier, motion guards and endThreshold on Table
* docs: record the interactive border tier on the text field family
* docs: record the interactive border tier on Textarea
* docs: record the interactive border tier on Checkbox and Toggle
* docs: record the interactive border tier on ToggleGroup
* docs: record the interactive border tier on Stepper
* docs: record the error text tier on ErrorState
* docs: record the reduced-motion guard on the Tabs indicator
* docs: record the reduced-motion guard on Collapsible and Accordion
